### PR TITLE
fix incorrect file suffix for cover for Tale of Two Cities

### DIFF
--- a/books.json
+++ b/books.json
@@ -1265,7 +1265,7 @@
     "name":"A Tale of Two Cities",
     "covers":[
       {
-        "filename":"rtc_A+Tale+of+Two+Cities_Alexis+Lampley.jpg",
+        "filename":"rtc_A+Tale+of+Two+Cities_Alexis+Lampley.jpeg",
         "artist":"Alexis Lampley"
       },
       {


### PR DESCRIPTION
changed rtc_A+Tale+of+Two+Cities_Alexis+Lampley.jpg -> rtc_A+Tale+of+Two+Cities_Alexis+Lampley.jpeg
